### PR TITLE
Loginlogout us14

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user
-    User.find(session[:user_id])
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
   def current_merchant?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,16 +5,21 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by(email: params[:email])
-    session[:user_id] = user.id
-    if user.role == "admin"
-      flash[:success] = "Welcome Admin, #{user.name}!"
-      redirect_to(admin_dashboard_path)
-    elsif user.role == "merchant"
-      flash[:success] = "Welcome Merchant, #{user.name}!"
-      redirect_to(merchants_dashboard_path)
-    else
-      flash[:success] = "Welcome, #{user.name}. You are logged in!"
-      redirect_to(profile_path)
+    if user == nil || !user.authenticate(params[:password])
+      flash[:failure] = "Incorrect email or password."
+      redirect_to(login_path)
+    else 
+      session[:user_id] = user.id
+      if user.role == "admin"
+        flash[:success] = "Welcome Admin, #{user.name}!"
+        redirect_to(admin_dashboard_path)
+      elsif user.role == "merchant"
+        flash[:success] = "Welcome Merchant, #{user.name}!"
+        redirect_to(merchants_dashboard_path)
+      else
+        flash[:success] = "Welcome, #{user.name}. You are logged in!"
+        redirect_to(profile_path)
+      end
     end
   end
 

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "Login Page", type: :feature do
     end
 
     it "can login a regular user" do
-
       expect(current_path).to eq("/login")
 
       fill_in :email, with: @user.email
@@ -47,7 +46,6 @@ RSpec.describe "Login Page", type: :feature do
     end
 
     it "can login an admin user" do
-
       expect(current_path).to eq("/login")
 
       fill_in :email, with: @admin.email
@@ -60,6 +58,42 @@ RSpec.describe "Login Page", type: :feature do
       expect(current_path).to eq("/admin/dashboard")
 
       expect(page).to have_content("Welcome Admin, #{@admin.name}!")
+    end
+
+    it "cannot login user with incorrect email" do 
+      expect(current_path).to eq("/login")
+
+      fill_in :email, with: "incorrect email"
+      fill_in  :password, with: @user.password
+      click_button "Login"
+
+      expect(current_path).to eq("/login")
+
+      expect(page).to have_content("Incorrect email or password.")
+    end
+
+    it "cannot login user with incorrect password" do 
+      expect(current_path).to eq("/login")
+
+      fill_in :email, with: @user.email
+      fill_in  :password, with: "incorrect password"
+      click_button "Login"
+
+      expect(current_path).to eq("/login")
+
+      expect(page).to have_content("Incorrect email or password.")
+    end
+
+    it "cannot login user with incorrect email and incorrect password" do 
+      expect(current_path).to eq("/login")
+
+      fill_in :email, with: "incorrect email"
+      fill_in  :password, with: "incorrect password"
+      click_button "Login"
+
+      expect(current_path).to eq("/login")
+
+      expect(page).to have_content("Incorrect email or password.")
     end
 
     # it "cannot visit merchant or admin dashboard as a regular user" do


### PR DESCRIPTION
closes #44 

**Contributor:**
- Leah

**What was changed:**
- Display error message if user logs in with bad credentials (incorrect email and/or password) and redirect user to the login form
