### PR TITLE
User profile page us19

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,9 @@
-<h1>Profile</h1>
+<h1><%= current_user.name %></h1>
+
+<ul>
+  <li>Address: <%= current_user.address %></li>
+  <li>City: <%= current_user.city %></li>
+  <li>State: <%= current_user.state %></li>
+  <li>Zip: <%= current_user.zip %></li>
+  <li>Zip: <%= current_user.email %></li>
+</ul>

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "user profile page", type: :feature do
+  describe "As a logged-in user" do
+
+    before :each do
+      @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+ 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit "/profile"
+    end
+
+    it "can see my profile data (except for password)" do
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+      expect(page).to have_content(@user.email)
+      expect(page).to_not have_content(@user.password)
+      expect(page).to_not have_content(@user.password_confirmation)
+    end
+  end
+end


### PR DESCRIPTION
closes #21 

**Contributor**
- Leah

**What was done**
- Added test for user's profile page to display user's info, but not display password
- Added current_user's info to profile page view 

**Tech notes**
- I was able to use rspec's stub method to simulate a user being logged in instead of having to click login, fill in info, then submit
  - `allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)`
  - Could clean up some of our code elsewhere where we need a logged in user so I'll add a new issue for this as a refactor!