### PR TITLE
User profile page us22

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+
+--format NyanCatFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,8 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
+group :test do 
+  gem "nyan-cat-formatter"
+end
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nyan-cat-formatter (0.12.0)
+      rspec (>= 2.99, >= 2.14.2, < 4)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -140,6 +142,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -212,6 +218,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  nyan-cat-formatter
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.7)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
     if user == nil || !user.authenticate(params[:password])
-      flash[:failure] = "Incorrect email or password."
+      flash[:error] = "Incorrect email or password."
       redirect_to(login_path)
     else
       session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,8 +44,16 @@ class UsersController < ApplicationController
         render :change_password
       end
     else 
-      flash[:success] = "Your profile info has been updated."
-      redirect_to profile_path
+      if current_user.save
+        flash[:success] = "Your profile info has been updated."
+        redirect_to profile_path
+      elsif User.email_exists?(current_user.email)
+        flash[:error] = current_user.errors.full_messages.to_sentence
+        render :edit
+      else
+        flash[:error] = current_user.errors.full_messages.to_sentence
+        render :edit
+        end
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,12 +10,10 @@ class UsersController < ApplicationController
       flash[:success] = "Welcome, #{@user.name}"
       redirect_to '/profile'
     elsif User.email_exists?(@user.email)
-      flash[:error] = @user.errors.full_messages.to_sentence
       @user.email = nil
-      render :new
+      user_fails_create_validation
     else
-      flash[:error] = @user.errors.full_messages.to_sentence
-      render :new
+      user_fails_create_validation
     end
   end
 
@@ -40,25 +38,27 @@ class UsersController < ApplicationController
         flash[:success] = "Your password has been updated."
         redirect_to profile_path
       else 
-        flash[:error] = "The passwords entered do not match."
+        flash[:error] = current_user.errors.full_messages.to_sentence
         render :change_password
       end
     else 
       if current_user.save
         flash[:success] = "Your profile info has been updated."
         redirect_to profile_path
-      elsif User.email_exists?(current_user.email)
-        flash[:error] = current_user.errors.full_messages.to_sentence
-        render :edit
       else
         flash[:error] = current_user.errors.full_messages.to_sentence
         render :edit
-        end
+      end
     end
   end
 
   private
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
+  end
+
+  def user_fails_create_validation
+    flash[:error] = @user.errors.full_messages.to_sentence
+    render :new
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,11 +10,11 @@ class UsersController < ApplicationController
       flash[:success] = "Welcome, #{@user.name}"
       redirect_to '/profile'
     elsif User.email_exists?(@user.email)
-      flash[:failure] = @user.errors.full_messages.to_sentence
+      flash[:error] = @user.errors.full_messages.to_sentence
       @user.email = nil
       render :new
     else
-      flash[:failure] = @user.errors.full_messages.to_sentence
+      flash[:error] = @user.errors.full_messages.to_sentence
       render :new
     end
   end
@@ -26,12 +26,30 @@ class UsersController < ApplicationController
   end
 
   def edit
+    if params[:password]
+      render :change_password
+    else 
+      render :edit
+    end
   end
 
   def update
     current_user.update(user_params)
-    flash[:success] = "Your profile info has been updated."
-    redirect_to profile_path
+    if user_params[:password]
+      # password is saving in both conditionals
+      if current_user.save
+        flash[:success] = "Your password has been updated."
+        redirect_to profile_path
+      else 
+        flash[:error] = "The passwords entered do not match."
+        render :change_password
+      end
+    else 
+      # profile info doesn't save to db or reflect updates on profile but tests are passing
+      require 'pry'; binding.pry
+      flash[:success] = "Your profile info has been updated."
+      redirect_to profile_path
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,6 @@ class UsersController < ApplicationController
   def update
     current_user.update(user_params)
     if user_params[:password]
-      # password is saving in both conditionals
       if current_user.save
         flash[:success] = "Your password has been updated."
         redirect_to profile_path
@@ -45,8 +44,6 @@ class UsersController < ApplicationController
         render :change_password
       end
     else 
-      # profile info doesn't save to db or reflect updates on profile but tests are passing
-      require 'pry'; binding.pry
       flash[:success] = "Your profile info has been updated."
       redirect_to profile_path
     end
@@ -56,5 +53,4 @@ class UsersController < ApplicationController
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
 
-  validates_presence_of :name, :address, :city, :state, :zip, :password, :password_confirmation, :role
+  validates_presence_of :name, :address, :city, :state, :zip, :role
+
+  validates :password, :presence => true, :confirmation => true, :on => :create
+  validates :password_confirmation, :presence => true, :confirmation => true, :on => :create
 
   validates :email, uniqueness: true, presence: true
 

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -1,12 +1,11 @@
 <h1>Change Password</h1>
 
 <%= form_tag "edit", method: :patch do %>
+  <%= label_tag :password %><br>
+  <%= text_field_tag :password, "New Password" %><br>
 
-<%= label_tag :password %><br>
-<%= text_field_tag :password, "New Password" %><br>
+  <%= label_tag :password_confirmation %><br>
+  <%= text_field_tag :password_confirmation, "New Password Confirmation" %><br>
 
-<%= label_tag :password_confirmation %><br>
-<%= text_field_tag :password_confirmation, "New Password Confirmation" %><br>
-
-<%= submit_tag "Change Password", class: :button %>
+  <%= submit_tag "Change Password", class: :button %>
 <% end %>

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -1,0 +1,12 @@
+<h1>Change Password</h1>
+
+<%= form_tag "edit", method: :patch do %>
+
+<%= label_tag :password %><br>
+<%= text_field_tag :password, "New Password" %><br>
+
+<%= label_tag :password_confirmation %><br>
+<%= text_field_tag :password_confirmation, "New Password Confirmation" %><br>
+
+<%= submit_tag "Change Password", class: :button %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,11 +1,13 @@
 <h1><%= current_user.name %></h1>
+<% binding.pry %>
 
 <ul>
   <li>Address: <%= current_user.address %></li>
   <li>City: <%= current_user.city %></li>
   <li>State: <%= current_user.state %></li>
   <li>Zip: <%= current_user.zip %></li>
-  <li>Zip: <%= current_user.email %></li>
+  <li>Email: <%= current_user.email %></li>
 </ul>
 
-<%= link_to "Edit Profile", profile_edit_path %>
+<%= link_to "Edit Profile", profile_edit_path %><br>
+<%= link_to "Change Password", profile_edit_path(password: true) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,4 @@
 <h1><%= current_user.name %></h1>
-<% binding.pry %>
 
 <ul>
   <li>Address: <%= current_user.address %></li>

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "edit user profile data", type: :feature do
       click_button "Change Password"
 
       expect(current_path).to eq("/profile/edit")
-      expect(page).to have_content("The passwords entered do not match.")
+      expect(page).to have_content("Password confirmation doesn't match Password")
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -3,22 +3,23 @@ require 'rails_helper'
 RSpec.describe "edit user profile data", type: :feature do
   describe "As a logged-in user" do
     before :each do
-      @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+      @user_1 = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+      @user_2 = User.create(name:"Patrick Schwayze", address:"444 Street", city:"Denver", state:"CO", zip:"40404", email: "dirtydancing@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
  
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
     end
     
     it "can see form pre-populated with current info except for password" do 
       visit profile_edit_path
 
-      expect(find_field(:name).value).to eq(@user.name)
-      expect(find_field(:address).value).to eq(@user.address)
-      expect(find_field(:city).value).to eq(@user.city)
-      expect(find_field(:state).value).to eq(@user.state)
-      expect(find_field(:zip).value).to eq(@user.zip)
-      expect(find_field(:email).value).to eq(@user.email)
+      expect(find_field(:name).value).to eq(@user_1.name)
+      expect(find_field(:address).value).to eq(@user_1.address)
+      expect(find_field(:city).value).to eq(@user_1.city)
+      expect(find_field(:state).value).to eq(@user_1.state)
+      expect(find_field(:zip).value).to eq(@user_1.zip)
+      expect(find_field(:email).value).to eq(@user_1.email)
       expect(page).to_not have_content("Password")
-      expect(page).to_not have_content(@user.password)
+      expect(page).to_not have_content(@user_1.password)
     end
 
     it "can change information" do 
@@ -40,6 +41,16 @@ RSpec.describe "edit user profile data", type: :feature do
       expect(page).to have_content("NY")
       expect(page).to have_content("12345")
       expect(page).to have_content("zealot@gmail.com")
+    end
+
+    it "can require a unique email address" do 
+      visit profile_edit_path
+
+      fill_in(:email, with: @user_2.email)
+      click_button "Update"
+
+      expect(current_path).to eq(profile_edit_path)
+      expect(page).to have_content("Email has already been taken")
     end
 
     it "can change password" do 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe "edit user profile data", type: :feature do
       @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
  
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
-      visit profile_edit_path
     end
-
+    
     it "can see form pre-populated with current info except for password" do 
+      visit profile_edit_path
+
       expect(find_field(:name).value).to eq(@user.name)
       expect(find_field(:address).value).to eq(@user.address)
       expect(find_field(:city).value).to eq(@user.city)
@@ -22,6 +22,8 @@ RSpec.describe "edit user profile data", type: :feature do
     end
 
     it "can change information" do 
+      visit profile_edit_path
+
       fill_in(:name, with: "LHJE")
       fill_in(:address, with: "555 Street")
       fill_in(:city, with: "New York")
@@ -38,6 +40,33 @@ RSpec.describe "edit user profile data", type: :feature do
       expect(page).to have_content("NY")
       expect(page).to have_content("12345")
       expect(page).to have_content("zealot@gmail.com")
+    end
+
+    it "can change password" do 
+      visit profile_path
+      click_link "Change Password"
+
+      expect(find_field(:password).value).to eq("New Password")
+      expect(find_field(:password_confirmation).value).to eq("New Password Confirmation")
+
+      fill_in(:password, with: "newpassword")
+      fill_in(:password_confirmation, with: "newpassword")
+      click_button "Change Password"
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Your password has been updated.")
+    end
+
+    it "cannot change password if passwords do not match" do 
+      visit profile_path
+      click_link "Change Password"
+
+      fill_in(:password, with: "newpassword")
+      fill_in(:password_confirmation, with: "doesnotmatch")
+      click_button "Change Password"
+
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("The passwords entered do not match.")
     end
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -26,5 +26,11 @@ RSpec.describe "user profile page", type: :feature do
       click_link "Edit Profile"
       expect(current_path).to eq("/profile/edit")
     end
+
+    it "can link to form for changing password" do 
+      click_link "Change Password"
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("Change Password")
+    end
   end
 end


### PR DESCRIPTION
closes #25 

**Contributor**
- Leah

**What was changed**
- Added test to confirm that user can't edit profile data w/ an email address that already exists in database
- Updated update action in users controller to display flash message if user has an entered an existing email, then send user back to edit form
- Refactor: added `user_fails_create_validation` helper method to dry up a few lines in users controller