### PR TITLE
User profile page

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --require spec_helper
+
+--format NyanCatFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,8 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
 end
 
+group :test do 
+  gem "nyan-cat-formatter"
+end
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    nyan-cat-formatter (0.12.0)
+      rspec (>= 2.99, >= 2.14.2, < 4)
     pg (1.2.3)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -140,6 +142,10 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -212,6 +218,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)
+  nyan-cat-formatter
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :cart, :current_user
+  helper_method :cart, :current_user, :current_visitor?
 
   def cart
     @cart ||= Cart.new(session[:cart] ||= Hash.new(0))

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
     if user == nil || !user.authenticate(params[:password])
-      flash[:failure] = "Incorrect email or password."
+      flash[:error] = "Incorrect email or password."
       redirect_to(login_path)
     else
       session[:user_id] = user.id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,15 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+    current_user.update(user_params)
+    flash[:success] = "Your profile info has been updated."
+    redirect_to profile_path
+  end
+
   private
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,12 +10,10 @@ class UsersController < ApplicationController
       flash[:success] = "Welcome, #{@user.name}"
       redirect_to '/profile'
     elsif User.email_exists?(@user.email)
-      flash[:error] = @user.errors.full_messages.to_sentence
       @user.email = nil
-      render :new
+      user_fails_create_validation
     else
-      flash[:error] = @user.errors.full_messages.to_sentence
-      render :new
+      user_fails_create_validation
     end
   end
 
@@ -40,17 +38,27 @@ class UsersController < ApplicationController
         flash[:success] = "Your password has been updated."
         redirect_to profile_path
       else 
-        flash[:error] = "The passwords entered do not match."
+        flash[:error] = current_user.errors.full_messages.to_sentence
         render :change_password
       end
     else 
-      flash[:success] = "Your profile info has been updated."
-      redirect_to profile_path
+      if current_user.save
+        flash[:success] = "Your profile info has been updated."
+        redirect_to profile_path
+      else
+        flash[:error] = current_user.errors.full_messages.to_sentence
+        render :edit
+      end
     end
   end
 
   private
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
+  end
+
+  def user_fails_create_validation
+    flash[:error] = @user.errors.full_messages.to_sentence
+    render :new
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,11 +10,11 @@ class UsersController < ApplicationController
       flash[:success] = "Welcome, #{@user.name}"
       redirect_to '/profile'
     elsif User.email_exists?(@user.email)
-      flash[:failure] = @user.errors.full_messages.to_sentence
+      flash[:error] = @user.errors.full_messages.to_sentence
       @user.email = nil
       render :new
     else
-      flash[:failure] = @user.errors.full_messages.to_sentence
+      flash[:error] = @user.errors.full_messages.to_sentence
       render :new
     end
   end
@@ -26,17 +26,31 @@ class UsersController < ApplicationController
   end
 
   def edit
+    if params[:password]
+      render :change_password
+    else 
+      render :edit
+    end
   end
 
   def update
     current_user.update(user_params)
-    flash[:success] = "Your profile info has been updated."
-    redirect_to profile_path
+    if user_params[:password]
+      if current_user.save
+        flash[:success] = "Your password has been updated."
+        redirect_to profile_path
+      else 
+        flash[:error] = "The passwords entered do not match."
+        render :change_password
+      end
+    else 
+      flash[:success] = "Your profile info has been updated."
+      redirect_to profile_path
+    end
   end
 
   private
   def user_params
     params.permit(:name, :address, :city, :state, :zip, :email, :password, :password_confirmation)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
 
-  validates_presence_of :name, :address, :city, :state, :zip, :password, :password_confirmation, :role
+  validates_presence_of :name, :address, :city, :state, :zip, :role
+
+  validates :password, :presence => true, :confirmation => true, :on => :create
+  validates :password_confirmation, :presence => true, :confirmation => true, :on => :create
 
   validates :email, uniqueness: true, presence: true
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,20 +1,23 @@
 <%= form_tag path, method: method do %>
 <%= label_tag :name %><br>
-<%= text_field_tag :name, @user.name, placeholder: "Name" %><br>
+<%= text_field_tag :name, current_user.name, placeholder: "Name" %><br>
 <%= label_tag :address %><br>
-<%= text_field_tag :address, @user.address, placeholder: "Address" %><br>
+<%= text_field_tag :address, current_user.address, placeholder: "Address" %><br>
 <%= label_tag :city %><br>
-<%= text_field_tag :city, @user.city, placeholder: "City" %><br>
+<%= text_field_tag :city, current_user.city, placeholder: "City" %><br>
 <%= label_tag :state %><br>
-<%= text_field_tag :state, @user.state, placeholder: "State" %><br>
+<%= text_field_tag :state, current_user.state, placeholder: "State" %><br>
 <%= label_tag :zip %><br>
-<%= text_field_tag :zip, @user.zip, placeholder: "Zip" %><br>
+<%= text_field_tag :zip, current_user.zip, placeholder: "Zip" %><br>
 <%= label_tag :email %><br>
-<%= text_field_tag :email, @user.email, placeholder: "Email" %><br>
-<%= label_tag :password %><br>
-<%= text_field_tag :password, nil, placeholder: "Password" %><br>
-<%= label_tag :password_confirmation %><br>
-<%= text_field_tag :password_confirmation, nil, placeholder: "Password Confirmation" %><br>
+<%= text_field_tag :email, current_user.email, placeholder: "Email" %><br>
+
+<% if current_visitor? %>
+  <%= label_tag :password %><br>
+  <%= text_field_tag :password, nil, placeholder: "Password" %><br>
+  <%= label_tag :password_confirmation %><br>
+  <%= text_field_tag :password_confirmation, nil, placeholder: "Password Confirmation" %><br>
+<% end %>
 
 <%= submit_tag button_text, class: :button %>
 <% end %>

--- a/app/views/users/change_password.html.erb
+++ b/app/views/users/change_password.html.erb
@@ -1,0 +1,11 @@
+<h1>Change Password</h1>
+
+<%= form_tag "edit", method: :patch do %>
+  <%= label_tag :password %><br>
+  <%= text_field_tag :password, "New Password" %><br>
+
+  <%= label_tag :password_confirmation %><br>
+  <%= text_field_tag :password_confirmation, "New Password Confirmation" %><br>
+
+  <%= submit_tag "Change Password", class: :button %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Edit Profile</h1>
+
+<%= render :partial => "form", locals: { 
+  path: "/profile/edit", 
+  method: :patch, 
+  button_text: "Update" } %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,4 +3,5 @@
 <%= render :partial => "form", locals: { 
   path: "/users", 
   method: :post, 
+  current_user: @user,
   button_text: "Sign-up" } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,3 +7,5 @@
   <li>Zip: <%= current_user.zip %></li>
   <li>Zip: <%= current_user.email %></li>
 </ul>
+
+<%= link_to "Edit Profile", profile_edit_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,9 @@
-<h1>Profile</h1>
+<h1><%= current_user.name %></h1>
+
+<ul>
+  <li>Address: <%= current_user.address %></li>
+  <li>City: <%= current_user.city %></li>
+  <li>State: <%= current_user.state %></li>
+  <li>Zip: <%= current_user.zip %></li>
+  <li>Zip: <%= current_user.email %></li>
+</ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,7 +5,8 @@
   <li>City: <%= current_user.city %></li>
   <li>State: <%= current_user.state %></li>
   <li>Zip: <%= current_user.zip %></li>
-  <li>Zip: <%= current_user.email %></li>
+  <li>Email: <%= current_user.email %></li>
 </ul>
 
-<%= link_to "Edit Profile", profile_edit_path %>
+<%= link_to "Edit Profile", profile_edit_path %><br>
+<%= link_to "Change Password", profile_edit_path(password: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
   resources :users, only: [:create]
   get "/register", to: "users#new"
   get "/profile", to: "users#show"
-
+  get "profile/edit", to: "users#edit"
+  patch "profile/edit", to: "users#update"
+  
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe "edit user profile data", type: :feature do
       @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
  
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
-
-      visit profile_edit_path
     end
-
+    
     it "can see form pre-populated with current info except for password" do 
+      visit profile_edit_path
+
       expect(find_field(:name).value).to eq(@user.name)
       expect(find_field(:address).value).to eq(@user.address)
       expect(find_field(:city).value).to eq(@user.city)
@@ -22,6 +22,8 @@ RSpec.describe "edit user profile data", type: :feature do
     end
 
     it "can change information" do 
+      visit profile_edit_path
+
       fill_in(:name, with: "LHJE")
       fill_in(:address, with: "555 Street")
       fill_in(:city, with: "New York")
@@ -38,6 +40,33 @@ RSpec.describe "edit user profile data", type: :feature do
       expect(page).to have_content("NY")
       expect(page).to have_content("12345")
       expect(page).to have_content("zealot@gmail.com")
+    end
+
+    it "can change password" do 
+      visit profile_path
+      click_link "Change Password"
+
+      expect(find_field(:password).value).to eq("New Password")
+      expect(find_field(:password_confirmation).value).to eq("New Password Confirmation")
+
+      fill_in(:password, with: "newpassword")
+      fill_in(:password_confirmation, with: "newpassword")
+      click_button "Change Password"
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Your password has been updated.")
+    end
+
+    it "cannot change password if passwords do not match" do 
+      visit profile_path
+      click_link "Change Password"
+
+      fill_in(:password, with: "newpassword")
+      fill_in(:password_confirmation, with: "doesnotmatch")
+      click_button "Change Password"
+
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("The passwords entered do not match.")
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -3,22 +3,23 @@ require 'rails_helper'
 RSpec.describe "edit user profile data", type: :feature do
   describe "As a logged-in user" do
     before :each do
-      @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+      @user_1 = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+      @user_2 = User.create(name:"Patrick Schwayze", address:"444 Street", city:"Denver", state:"CO", zip:"40404", email: "dirtydancing@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
  
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
     end
     
     it "can see form pre-populated with current info except for password" do 
       visit profile_edit_path
 
-      expect(find_field(:name).value).to eq(@user.name)
-      expect(find_field(:address).value).to eq(@user.address)
-      expect(find_field(:city).value).to eq(@user.city)
-      expect(find_field(:state).value).to eq(@user.state)
-      expect(find_field(:zip).value).to eq(@user.zip)
-      expect(find_field(:email).value).to eq(@user.email)
+      expect(find_field(:name).value).to eq(@user_1.name)
+      expect(find_field(:address).value).to eq(@user_1.address)
+      expect(find_field(:city).value).to eq(@user_1.city)
+      expect(find_field(:state).value).to eq(@user_1.state)
+      expect(find_field(:zip).value).to eq(@user_1.zip)
+      expect(find_field(:email).value).to eq(@user_1.email)
       expect(page).to_not have_content("Password")
-      expect(page).to_not have_content(@user.password)
+      expect(page).to_not have_content(@user_1.password)
     end
 
     it "can change information" do 
@@ -40,6 +41,16 @@ RSpec.describe "edit user profile data", type: :feature do
       expect(page).to have_content("NY")
       expect(page).to have_content("12345")
       expect(page).to have_content("zealot@gmail.com")
+    end
+
+    it "can require a unique email address" do 
+      visit profile_edit_path
+
+      fill_in(:email, with: @user_2.email)
+      click_button "Update"
+
+      expect(current_path).to eq(profile_edit_path)
+      expect(page).to have_content("Email has already been taken")
     end
 
     it "can change password" do 
@@ -66,7 +77,7 @@ RSpec.describe "edit user profile data", type: :feature do
       click_button "Change Password"
 
       expect(current_path).to eq("/profile/edit")
-      expect(page).to have_content("The passwords entered do not match.")
+      expect(page).to have_content("Password confirmation doesn't match Password")
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "edit user profile data", type: :feature do
+  describe "As a logged-in user" do
+    before :each do
+      @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+ 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit profile_edit_path
+    end
+
+    it "can see form pre-populated with current info except for password" do 
+      expect(find_field(:name).value).to eq(@user.name)
+      expect(find_field(:address).value).to eq(@user.address)
+      expect(find_field(:city).value).to eq(@user.city)
+      expect(find_field(:state).value).to eq(@user.state)
+      expect(find_field(:zip).value).to eq(@user.zip)
+      expect(find_field(:email).value).to eq(@user.email)
+      expect(page).to_not have_content("Password")
+      expect(page).to_not have_content(@user.password)
+    end
+
+    it "can change information" do 
+      fill_in(:name, with: "LHJE")
+      fill_in(:address, with: "555 Street")
+      fill_in(:city, with: "New York")
+      fill_in(:state, with: "NY")
+      fill_in(:zip, with: "12345")
+      fill_in(:email, with: "zealot@gmail.com")
+      click_button "Update"
+
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Your profile info has been updated.")
+      expect(page).to have_content("LHJE")
+      expect(page).to have_content("555 Street")
+      expect(page).to have_content("New York")
+      expect(page).to have_content("NY")
+      expect(page).to have_content("12345")
+      expect(page).to have_content("zealot@gmail.com")
+    end
+  end
+end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -26,5 +26,11 @@ RSpec.describe "user profile page", type: :feature do
       click_link "Edit Profile"
       expect(current_path).to eq("/profile/edit")
     end
+
+    it "can link to form for changing password" do 
+      click_link "Change Password"
+      expect(current_path).to eq("/profile/edit")
+      expect(page).to have_content("Change Password")
+    end
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "user profile page", type: :feature do
+  describe "As a logged-in user" do
+
+    before :each do
+      @user = User.create(name:"Luke Hunter James-Erickson", address:"123 Lane", city:"Denver", state:"CO", zip:"88888", email: "tombroke@gmail.com", password:"Iamapassword", password_confirmation:"Iamapassword", role: 0)
+ 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
+      visit "/profile"
+    end
+
+    it "can see my profile data (except for password)" do
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+      expect(page).to have_content(@user.email)
+      expect(page).to_not have_content(@user.password)
+      expect(page).to_not have_content(@user.password_confirmation)
+    end
+  end
+end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -21,5 +21,10 @@ RSpec.describe "user profile page", type: :feature do
       expect(page).to_not have_content(@user.password)
       expect(page).to_not have_content(@user.password_confirmation)
     end
+
+    it "can link to form for editing profile data" do 
+      click_link "Edit Profile"
+      expect(current_path).to eq("/profile/edit")
+    end
   end
 end


### PR DESCRIPTION
Closes milestone User Profile Page

**Contributor**
- Leah

**What was changed**
- This series of stories allows users to view their profile page, edit profile data, and change password 
  - Editing profile info and changing password are separate forms per user stories
- When updating info, email address must be unique and password and confirmation must match 

**Other notes**
- Added nyan cat to gem file for FuNnEr testing