### PR TITLE
Merchant index us39

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -30,11 +30,11 @@ class MerchantsController < ApplicationController
     if params[:toggle_status]
       @merchant.toggle_status
       if @merchant.active?
-        flash[:success] = "#{@merchant.name} is now active"
-        @merchant.enable_items
+        # @merchant.enable_items
+        flash[:success] = "#{@merchant.name} is now enabled"
       end
+      # @merchant.disable_items
         flash[:success] = "#{@merchant.name} is now disabled"
-        @merchant.disable_items
       redirect_to admin_merchants_path
     else 
       @merchant.update(merchant_params)
@@ -57,5 +57,4 @@ class MerchantsController < ApplicationController
   def merchant_params
     params.permit(:name,:address,:city,:state,:zip)
   end
-
 end

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -29,8 +29,12 @@ class MerchantsController < ApplicationController
     @merchant = Merchant.find(params[:id])
     if params[:toggle_status]
       @merchant.toggle_status
-      flash[:success] = "#{@merchant.name} is now disabled"
-      @merchant.disable_items
+      if @merchant.active?
+        flash[:success] = "#{@merchant.name} is now active"
+        @merchant.enable_items
+      end
+        flash[:success] = "#{@merchant.name} is now disabled"
+        @merchant.disable_items
       redirect_to admin_merchants_path
     else 
       @merchant.update(merchant_params)

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -30,6 +30,7 @@ class MerchantsController < ApplicationController
     if params[:toggle_status]
       @merchant.toggle(:active?).save
       flash[:success] = "#{@merchant.name} is now disabled"
+      @merchant.disable_items
       redirect_to admin_merchants_path
     else 
       @merchant.update(merchant_params)

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -28,7 +28,7 @@ class MerchantsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:id])
     if params[:toggle_status]
-      @merchant.toggle(:active?).save
+      @merchant.toggle_status
       flash[:success] = "#{@merchant.name} is now disabled"
       @merchant.disable_items
       redirect_to admin_merchants_path

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -30,11 +30,12 @@ class MerchantsController < ApplicationController
     if params[:toggle_status]
       @merchant.toggle_status
       if @merchant.active?
-        # @merchant.enable_items
+        @merchant.enable_items
         flash[:success] = "#{@merchant.name} is now enabled"
-      end
-      # @merchant.disable_items
+      else
+        @merchant.disable_items
         flash[:success] = "#{@merchant.name} is now disabled"
+      end
       redirect_to admin_merchants_path
     else 
       @merchant.update(merchant_params)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -32,4 +32,8 @@ class Merchant <ApplicationRecord
   def disable_items 
     items.update_all(active?: false)
   end
+
+  def enable_items 
+    items.update_all(active?: true)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,4 +25,7 @@ class Merchant <ApplicationRecord
     item_orders.distinct.joins(:order).pluck(:city)
   end
 
+  def disable_items 
+    items.update_all(active?: false)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,6 +25,10 @@ class Merchant <ApplicationRecord
     item_orders.distinct.joins(:order).pluck(:city)
   end
 
+  def toggle_status
+    toggle(:active?).save
+  end
+
   def disable_items 
     items.update_all(active?: false)
   end

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -6,13 +6,13 @@
       <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
 
       <% if current_admin? %>
-        <% if merchant.active? %>
-          <p>Status: Active</p>
-          <%= link_to "Disable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
-        <% else %>
-          <p>Status: Inactive</p>
-          <%= link_to "Enable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
-        <% end %>
+      <% if merchant.active? %>
+      <p>Status: Active</p>
+      <%= link_to "Disable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
+      <% else %>
+        <p>Status: Inactive</p>
+        <%= link_to "Enable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
+      <% end %>
       <% end %>
     </section>
   <% end %>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -7,10 +7,11 @@
 
       <% if current_admin? %>
         <% if merchant.active? %>
-         <p>Status: Active</p>
+          <p>Status: Active</p>
           <%= link_to "Disable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
         <% else %>
-          <p>Status: Disabled</p>
+          <p>Status: Inactive</p>
+          <%= link_to "Enable", merchant_update_path(merchant, toggle_status: true), method: :patch %>
         <% end %>
       <% end %>
     </section>

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe 'merchant index page', type: :feature do
       @bike_shop.items.all?{ |item| expect(item.active?).to eq(false) }
     end
 
-
     it 'can enable an inactive merchant' do
       within("#merchant-#{@dog_shop.id}") do 
         expect(page).to have_content("Status: Inactive")
@@ -83,6 +82,14 @@ RSpec.describe 'merchant index page', type: :feature do
         expect(page).to_not have_button("Enable")
         expect(page).to have_link("Disable")
       end
+    end
+
+    it "can enable all merchant's items when merchant is enabled" do
+      within("#merchant-#{@dog_shop.id}") do 
+        click_link "Enable"
+      end
+
+      @dog_shop.items.all?{ |item| expect(item.active?).to eq(true) }
     end
   end
 end

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -66,5 +66,23 @@ RSpec.describe 'merchant index page', type: :feature do
 
       @bike_shop.items.all?{ |item| expect(item.active?).to eq(false) }
     end
+
+
+    it 'can enable an inactive merchant' do
+      within("#merchant-#{@dog_shop.id}") do 
+        expect(page).to have_content("Status: Inactive")
+        expect(page).to have_link("Enable")
+        click_link "Enable"
+      end
+
+      expect(current_path).to eq ('/admin/merchants')
+      expect(page).to have_content("#{@dog_shop.name} is now enabled")
+
+      within("#merchant-#{@dog_shop.id}") do 
+        expect(page).to have_content("Status: Active")
+        expect(page).to_not have_button("Enable")
+        expect(page).to have_button("Disable")
+      end
+    end
   end
 end

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'merchant index page', type: :feature do
+  before :each do
+    @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
+    @pawn_shop = Merchant.create!(name: "EZPAWN", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203)
+    @dog_shop = Merchant.create(name: "Meg's Dog Shop", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203, active?: false)
+    
+    @bike_shop_employee = User.create(name:"Leah", address:"123 Sesame Street", city:"New York", state:"NY", zip:"90210", email: "Leahsocool@gmail.com", password:"Imeanit", password_confirmation:"Imeanit", role: 1)
+    
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@bike_shop_employee)
+  end
+  
   describe 'as any logged in user' do
-    before :each do
-      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
-      @dog_shop = Merchant.create(name: "Meg's Dog Shop", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203)
-
-      @bike_shop_employee = User.create(name:"Leah", address:"123 Sesame Street", city:"New York", state:"NY", zip:"90210", email: "Leahsocool@gmail.com", password:"Imeanit", password_confirmation:"Imeanit", role: 1)
-
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@bike_shop_employee)
-    end
-
     it 'I can see a list of merchants in the system' do
       visit '/merchants'
 
-      expect(page).to have_link("Brian's Bike Shop")
-      expect(page).to have_link("Meg's Dog Shop")
+      expect(page).to have_link("#{@bike_shop.name}")
+      expect(page).to have_link("#{@pawn_shop.name}")
     end
 
     it 'I can see a link to create a new merchant' do
@@ -32,9 +33,6 @@ RSpec.describe 'merchant index page', type: :feature do
   describe 'as an admin' do
     before :each do 
       @admin = User.create(name:"Priya", address:"13 Elm Street", city:"Denver", state:"CO", zip:"66666", email: "priyavcool@gmail.com", password:"yuuuuuup", password_confirmation:"yuuuuuup", role: 2)
-
-      @bike_shop = Merchant.create!(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-      @dog_shop = Merchant.create!(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210, active?: false)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'merchant index page', type: :feature do
       expect(page).to have_content("#{@bike_shop.name} is now disabled")
 
       within("#merchant-#{@bike_shop.id}") do 
-        expect(page).to have_content("Status: Disabled")
+        expect(page).to have_content("Status: Inactive")
         expect(page).to_not have_button("Disable")
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe 'merchant index page', type: :feature do
       within("#merchant-#{@dog_shop.id}") do 
         expect(page).to have_content("Status: Active")
         expect(page).to_not have_button("Enable")
-        expect(page).to have_button("Disable")
+        expect(page).to have_link("Disable")
       end
     end
   end

--- a/spec/features/merchants/index_spec.rb
+++ b/spec/features/merchants/index_spec.rb
@@ -3,25 +3,25 @@ require 'rails_helper'
 RSpec.describe 'merchant index page', type: :feature do
   before :each do
     @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
-    @pawn_shop = Merchant.create!(name: "EZPAWN", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203)
+    @pawn_shop = Merchant.create!(name: "EZPAWN", address: '1025 Broadway', city: 'Denver', state: 'CO', zip: 80203)
     @dog_shop = Merchant.create(name: "Meg's Dog Shop", address: '123 Dog Rd.', city: 'Hershey', state: 'PA', zip: 80203, active?: false)
-    
-    @bike_shop_employee = User.create(name:"Leah", address:"123 Sesame Street", city:"New York", state:"NY", zip:"90210", email: "Leahsocool@gmail.com", password:"Imeanit", password_confirmation:"Imeanit", role: 1)
-    
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@bike_shop_employee)
   end
   
   describe 'as any logged in user' do
-    it 'I can see a list of merchants in the system' do
-      visit '/merchants'
+    before :each do 
+      @bike_shop_employee = User.create(name:"Leah", address:"123 Sesame Street", city:"New York", state:"NY", zip:"90210", email: "Leahsocool@gmail.com", password:"Imeanit", password_confirmation:"Imeanit", role: 1)
 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@bike_shop_employee)
+
+      visit '/merchants'
+    end
+
+    it 'I can see a list of merchants in the system' do
       expect(page).to have_link("#{@bike_shop.name}")
       expect(page).to have_link("#{@pawn_shop.name}")
     end
 
     it 'I can see a link to create a new merchant' do
-      visit '/merchants'
-
       expect(page).to have_link("New Merchant")
 
       click_on "New Merchant"
@@ -33,8 +33,12 @@ RSpec.describe 'merchant index page', type: :feature do
   describe 'as an admin' do
     before :each do 
       @admin = User.create(name:"Priya", address:"13 Elm Street", city:"Denver", state:"CO", zip:"66666", email: "priyavcool@gmail.com", password:"yuuuuuup", password_confirmation:"yuuuuuup", role: 2)
-
+      
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
+
+      @bike_shop.items.create!(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @bike_shop.items.create!(name: "GPS", description: "Track your splits", price: 150, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 5)
+      @bike_shop.items.create!(name: "Bottlecage", description: "Holds your water", price: 10, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 1, active?: false)
 
       visit '/admin/merchants'
     end
@@ -53,6 +57,14 @@ RSpec.describe 'merchant index page', type: :feature do
         expect(page).to have_content("Status: Disabled")
         expect(page).to_not have_button("Disable")
       end
+    end
+
+    it "can disable all merchant's items when merchant is disabled" do
+      within("#merchant-#{@bike_shop.id}") do 
+        click_link "Disable"
+      end
+
+      @bike_shop.items.all?{ |item| expect(item.active?).to eq(false) }
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -66,12 +66,12 @@ describe Merchant, type: :model do
     end
 
     it 'can disable all items' do 
-      @meg.toggle_item_status(false)
+      @meg.disable_items
       @meg.items.all?{ |item| expect(item.active?).to eq(false) }
     end
 
     it 'can enable all items' do 
-      @meg.toggle_item_status(true)
+      @meg.enable_items
       @meg.items.all?{ |item| expect(item.active?).to eq(true) }
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -57,17 +57,22 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to include("Hershey")
     end
 
-    it 'can disabled all items' do 
-      @meg.disable_items
-      @meg.items.all?{ |item| expect(item.active?).to eq(false) }
-    end
-
     it 'can toggle active status' do 
       @meg.toggle_status
       expect(@meg.active?).to eq(false)
 
       @pawn_shop.toggle_status
       expect(@pawn_shop.active?).to eq(true)
+    end
+
+    it 'can disable all items' do 
+      @meg.disable_items
+      @meg.items.all?{ |item| expect(item.active?).to eq(false) }
+    end
+
+    it 'can enable all items' do 
+      @meg.enable_items
+      @meg.items.all?{ |item| expect(item.active?).to eq(true) }
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -16,6 +16,7 @@ describe Merchant, type: :model do
   describe 'instance methods' do
     before(:each) do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      @pawn_shop = Merchant.create!(name: "EZPAWN", address: '1025 Broadway', city: 'Denver', state: 'CO', zip: 80203, active?: false)
 
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
       @watch = @meg.items.create!(name: "GPS", description: "Track your splits", price: 150, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 5)
@@ -59,6 +60,14 @@ describe Merchant, type: :model do
     it 'can disabled all items' do 
       @meg.disable_items
       @meg.items.all?{ |item| expect(item.active?).to eq(false) }
+    end
+
+    it 'can toggle active status' do 
+      @meg.toggle_status
+      expect(@meg.active?).to eq(false)
+
+      @pawn_shop.toggle_status
+      expect(@pawn_shop.active?).to eq(true)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -57,7 +57,8 @@ describe Merchant, type: :model do
     end
 
     it 'can disabled all items' do 
-
+      @meg.disable_items
+      @meg.items.all?{ |item| expect(item.active?).to eq(false) }
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -66,12 +66,12 @@ describe Merchant, type: :model do
     end
 
     it 'can disable all items' do 
-      @meg.disable_items
+      @meg.toggle_item_status(false)
       @meg.items.all?{ |item| expect(item.active?).to eq(false) }
     end
 
     it 'can enable all items' do 
-      @meg.enable_items
+      @meg.toggle_item_status(true)
       @meg.items.all?{ |item| expect(item.active?).to eq(true) }
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -16,8 +16,12 @@ describe Merchant, type: :model do
   describe 'instance methods' do
     before(:each) do
       @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+
       @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      @watch = @meg.items.create!(name: "GPS", description: "Track your splits", price: 150, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 5)
+      @bottlecage = @meg.items.create!(name: "Bottlecage", description: "Holds your water", price: 10, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 1, active?: false)
     end
+
     it 'no_orders' do
       expect(@meg.no_orders?).to eq(true)
 
@@ -30,13 +34,13 @@ describe Merchant, type: :model do
     it 'item_count' do
       chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 30, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
 
-      expect(@meg.item_count).to eq(2)
+      expect(@meg.item_count).to eq(4)
     end
 
     it 'average_item_price' do
       chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 40, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 22)
 
-      expect(@meg.average_item_price).to eq(70)
+      expect(@meg.average_item_price).to eq((@tire.price + @watch.price + @bottlecage.price + chain.price)/@meg.item_count)
     end
 
     it 'distinct_cities' do
@@ -52,5 +56,8 @@ describe Merchant, type: :model do
       expect(@meg.distinct_cities).to include("Hershey")
     end
 
+    it 'can disabled all items' do 
+
+    end
   end
 end


### PR DESCRIPTION
closes #39, #40, #14 

**Contributors**
- Driver(s): Leah
- Navigator(s): Grant
  
**What was changed:**
- When logged in as an admin, the merchant index page will display 'disable' link next to enabled merchants and 'enable' next to any disabled merchants
- When a merchant is disabled, all items for that merchant are disabled (active?: false)
- When a merchant is enabled, all items for that merchant are enabled (active?: true)
